### PR TITLE
Work around Pkg.test forcing bounds checks.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,19 @@
+# Pkg.test runs with --check_bounds=1, forcing all bounds checks.
+# This is incompatible with CUDAnative (see JuliaGPU/CUDAnative.jl#98)
+if Base.JLOptions().check_bounds == 1
+  cmd = ignorestatus(```
+    $(Base.julia_cmd())
+    --color=$(Base.have_color ? "yes" : "no")
+    --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
+    --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
+    --code-coverage=$(["none", "user", "all"][1+Base.JLOptions().code_coverage])
+    $(@__FILE__)
+    ```)
+  proc = spawn(cmd)
+  wait(proc)
+  exit(proc.exitcode)
+end
+
 using CuArrays
 using Base.Test
 


### PR DESCRIPTION
Kinda stinks, but does the job, and makes sure even CI runs all tests.