### PR TITLE
add missing useful convert functions

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -67,8 +67,11 @@ Base.collect(x::CuArray{T,N}) where {T,N} =
 
 Base.convert(::Type{T}, x::T) where T <: CuArray = x
 
-Base.convert(::Type{CuArray{T,N}}, xs::DenseArray{T,N}) where {T,N} =
-  copy!(CuArray{T,N}(size(xs)), xs)
+Base.convert(::Type{CuArray{T1,N}}, xs::DenseArray{T2,N}) where {T1,T2,N} =
+    copy!(CuArray{T1,N}(size(xs)), xs)
+
+Base.convert(::Type{CuArray{T1}}, xs::DenseArray{T2,N}) where {T1,T2,N} =
+    copy!(CuArray{T1}(size(xs)), xs)
 
 Base.convert(::Type{CuArray}, xs::DenseArray{T,N}) where {T,N} =
   convert(CuArray{T,N}, xs)


### PR DESCRIPTION
This PR makes the following operations possible,

```julia
using CuArrays
a = rand(Float64, 10, 20)
c1 = convert(CuArray{Float32}, a)
c2 = convert(CuArray{Float32,2}, a)
```